### PR TITLE
Fix 32-bit portability issues in NIF code

### DIFF
--- a/c_src/bitcask_nifs.c
+++ b/c_src/bitcask_nifs.c
@@ -187,9 +187,9 @@ typedef struct
 // An entry pointer may be tagged to indicate it really points to an
 // list of entries with different timestamps. Those are created when
 // there are concurrent iterations and updates.
-#define IS_ENTRY_LIST(p) ((uint64_t)p&1)
-#define GET_ENTRY_LIST_POINTER(p) ((bitcask_keydir_entry_head*)((uint64_t)p&(uint64_t)~1))
-#define MAKE_ENTRY_LIST_POINTER(p) ((bitcask_keydir_entry*)((uint64_t)p|(uint64_t)1))
+#define IS_ENTRY_LIST(p) ((uintptr_t)p&1)
+#define GET_ENTRY_LIST_POINTER(p) ((bitcask_keydir_entry_head*)((uintptr_t)p&(uintptr_t)~1))
+#define MAKE_ENTRY_LIST_POINTER(p) ((bitcask_keydir_entry*)((uintptr_t)p|(uintptr_t)1))
 
 // Holds values fetched from a regular entry or a snapshot from an entry list.
 typedef struct
@@ -2494,12 +2494,13 @@ ERL_NIF_TERM bitcask_nifs_file_pwrite(ErlNifEnv* env, int argc, const ERL_NIF_TE
 ERL_NIF_TERM bitcask_nifs_file_read(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 {
     bitcask_file_handle* handle;
-    size_t count;
+    unsigned long count_ul;
 
     if (enif_get_resource(env, argv[0], bitcask_file_RESOURCE, (void**)&handle) &&
-        enif_get_ulong(env, argv[1], &count))    /* Count */
+        enif_get_ulong(env, argv[1], &count_ul))    /* Count */
     {
         ErlNifBinary bin;
+        size_t count = count_ul;
         if (!enif_alloc_binary(count, &bin))
         {
             return enif_make_tuple2(env, ATOM_ERROR, ATOM_ALLOCATION_ERROR);


### PR DESCRIPTION
1. Use uintptr_t instead of uint64_t for pointer tagging macros (IS_ENTRY_LIST, GET_ENTRY_LIST_POINTER, MAKE_ENTRY_LIST_POINTER). Fixes warnings on 32-bit:

```
gcc -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m32 -march=i686 -mtune=generic -msse2 -mfpmath=sse -mstackrealign -fasynchronous-unwind-tables -fstack-clash-protection -mtls-dialect=gnu -c -I/usr/lib/erlang/usr/include c_src/bitcask_nifs.c -o c_src/bitcask_nifs.o
c_src/bitcask_nifs.c: In function ‘keydir_entry_hash’:
c_src/bitcask_nifs.c:190:27: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
  190 | #define IS_ENTRY_LIST(p) ((uint64_t)p&1)
      |                           ^
```

2. Use correct type for enif_get_ulong() - it expects unsigned long*, not size_t*, which may differ on some platforms.